### PR TITLE
Use deploy key for upstream sync push

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -28,7 +28,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up deploy key
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
         with:
           ssh-private-key: ${{ secrets.SYNC_DEPLOY_KEY }}
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,56 @@
+name: Sync from upstream
+
+on:
+  schedule:
+    - cron: '0 6 * * *'   # daily at 06:00 UTC
+  workflow_dispatch: {}
+
+concurrency:
+  group: sync-upstream-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/shipwright-io/build.git
+          git fetch upstream main
+
+      - name: Rebase onto upstream
+        run: |
+          UPSTREAM_SHA=$(git rev-parse upstream/main)
+          LOCAL_SHA=$(git rev-parse HEAD)
+
+          if [ "$UPSTREAM_SHA" = "$LOCAL_SHA" ]; then
+            echo "Already up to date with upstream ($LOCAL_SHA)"
+            exit 0
+          fi
+
+          echo "Syncing main: $LOCAL_SHA -> $UPSTREAM_SHA"
+
+          if ! git rebase upstream/main; then
+            echo "::error::Rebase conflict syncing 'main' from upstream."
+            echo "::error::Upstream SHA: $UPSTREAM_SHA | Mirror SHA: $LOCAL_SHA"
+            echo "::error::Manual resolution required."
+            git rebase --abort
+            exit 1
+          fi
+
+      - name: Push to mirror
+        run: git push origin main

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -27,6 +27,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Set up deploy key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SYNC_DEPLOY_KEY }}
+
       - name: Fetch upstream
         run: |
           git remote add upstream https://github.com/shipwright-io/build.git
@@ -53,4 +58,6 @@ jobs:
           fi
 
       - name: Push to mirror
-        run: git push origin main
+        run: |
+          git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
+          git push origin HEAD:main --force-with-lease


### PR DESCRIPTION
## Summary

- Adds webfactory/ssh-agent step to load a deploy key from SYNC_DEPLOY_KEY secret, enabling SSH-based push authentication
- Switches origin URL from HTTPS to SSH before pushing so the deploy key is used and --force-with-lease has valid tracking refs
- Uses --force-with-lease instead of plain git push since rebase rewrites mirror-only commit SHAs, requiring a non-fast-forward push

## Prerequisites

Before this workflow can run successfully, the following must be configured on the repo:

1. **Deploy key**: Generate an SSH key pair, add the public key under Settings > Deploy keys (with write access)
2. **Actions secret**: Add the private key as SYNC_DEPLOY_KEY under Settings > Secrets and variables > Actions
3. **Ruleset bypass**: Add the deploy key as a bypass actor in the ruleset that enforces Require PR and Block force pushes on main

## Test plan

- [x] Tested on personal fork with branch protection rules active
- [x] Verified rebase succeeds and produces new SHA for mirror-only commits
- [x] Verified force-push bypasses both Require PR and Block force pushes rules via deploy key
- [x] Verified --force-with-lease works correctly after switching origin to SSH